### PR TITLE
fix compile error in debug mode with assertion enabled

### DIFF
--- a/src/Function.cc
+++ b/src/Function.cc
@@ -59,7 +59,6 @@ v8::Handle<v8::Value> Function::NewInstance(Connection &connection, const v8::Ar
 
   // Save connection
   assert(self != nullptr);
-  assert(handle != nullptr);
   self->connection = &connection;
 
   // Lookup function interface
@@ -215,7 +214,6 @@ void Function::EIO_Invoke(uv_work_t *req)
   InvocationBaton *baton = static_cast<InvocationBaton*>(req->data);
 
   assert(baton != nullptr);
-  assert(baton->connectionHandle != nullptr);
   assert(baton->functionHandle != nullptr);
 
   baton->connection->LockMutex();


### PR DESCRIPTION
If I compile in debug mode I get these errors:
In file included from /usr/include/c++/4.8/cassert:43:0,
                 from /home/agebert/src/node-sapnwrfc/src/Function.cc:26:
/home/agebert/src/node-sapnwrfc/src/Function.cc: In static member function 'static v8::Handlev8::Value Function::NewInstance(Connection&, const v8::Arguments&)':
/home/agebert/src/node-sapnwrfc/src/Function.cc:65:10: error: 'handle' was not declared in this scope
   assert(handle != nullptr);
          ^
/home/agebert/src/node-sapnwrfc/src/Function.cc: In static member function 'static void Function::EIO_Invoke(uv_work_t*)':
/home/agebert/src/node-sapnwrfc/src/Function.cc:277:17: error: 'class Function::InvocationBaton' has no member named 'connectionHandle'
   assert(baton->connectionHandle != nullptr);
