### PR TITLE
More efficient processor and memory usage

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -1,4 +1,4 @@
-/* 
+/*
 -----------------------------------------------------------------------------
 Copyright (c) 2011 Joachim Dorner
 
@@ -46,7 +46,7 @@ static std::string convertToString(v8::Handle<v8::Value> const &str)
   if (s != nullptr) {
     return std::string(s, utf8String.length());
   }
-  
+
   return emptyString;
 }
 
@@ -54,7 +54,7 @@ static std::string convertToString(const SAP_UC *str)
 {
   v8::HandleScope scope;
   v8::Local<v8::String> utf16String = v8::String::New((const uint16_t*)(str));
-  
+
   return convertToString(utf16String);
 }
 
@@ -80,9 +80,9 @@ static SAP_UC* convertToSAPUC(v8::Handle<v8::Value> const &str) {
 static v8::Handle<v8::Value> RfcError(const RFC_ERROR_INFO &info)
 {
   v8::HandleScope scope;
-  
+
   v8::Local<v8::Value> e = v8::Exception::Error(v8::String::New((const uint16_t*)(info.message)));
-  
+
   v8::Local<v8::Object> obj = e->ToObject();
   obj->Set(v8::String::New("code"), v8::Integer::New(info.code));
   obj->Set(v8::String::New("group"), v8::Integer::New(info.group));
@@ -94,36 +94,19 @@ static v8::Handle<v8::Value> RfcError(const RFC_ERROR_INFO &info)
   obj->Set(v8::String::New("msgv2"), v8::String::New((const uint16_t*)(info.abapMsgV2)));
   obj->Set(v8::String::New("msgv3"), v8::String::New((const uint16_t*)(info.abapMsgV3)));
   obj->Set(v8::String::New("msgv4"), v8::String::New((const uint16_t*)(info.abapMsgV4)));
-  
+
   return scope.Close(obj);
 }
 
 static v8::Handle<v8::Value> RfcError(const char* message, v8::Handle<v8::Value> value)
 {
-  v8::HandleScope scope;
-  
   v8::Local<v8::String> exceptionString = v8::String::Concat(v8::String::New(message), value->ToString());
-  v8::Local<v8::Value> e = v8::Exception::Error(exceptionString);
-
-  return scope.Close(e->ToObject());
+  return v8::ThrowException(exceptionString);
 }
 
 static bool IsException(v8::Handle<v8::Value> value)
 {
-  v8::HandleScope scope;
-  const v8::Local<v8::Value> sample = v8::Exception::Error(v8::String::New(""));
-  const v8::Local<v8::String> protoSample = sample->ToObject()->ObjectProtoToString();
-  
-  if (!value->IsObject()) {
-    return false;
-  }
-  v8::Local<v8::String> protoReal = value->ToObject()->ObjectProtoToString();
-  if (protoReal->Equals(protoSample)) {
-    return true;
-  }
-  scope.Close(v8::Undefined());
-
-  return false;
+  return value->IsNativeError();
 }
 
 #endif /* COMMON_H_ */

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -1193,3 +1193,40 @@ v8::Handle<v8::Value> Function::BCDToInternal(const CHND container, const SAP_UC
 
   return scope.Close(value->ToNumber());
 }
+
+v8::Handle<v8::Value> Function::StructureGetter(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  v8::HandleScope scope;
+  Function *function = static_cast<Function *>(info.This()->GetPointerFromInternalField(0));
+  RFC_STRUCTURE_HANDLE struc = static_cast<RFC_STRUCTURE_HANDLE>(info.This()->GetPointerFromInternalField(1));
+  v8::Handle<v8::External> functionHandle = v8::Handle<v8::External>::Cast(info.This()->GetInternalField(2));
+  v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
+
+  if (!fieldDescriptions->Has(property)) {
+    v8::Handle<v8::Value> result;
+    return result;
+  }
+
+  v8::Handle<v8::External> wrappedFieldDesc = v8::Handle<v8::External>::Cast(fieldDescriptions->Get(property));
+  RFC_FIELD_DESC *fieldDesc = static_cast<RFC_FIELD_DESC *>(wrappedFieldDesc->Value());
+
+  return scope.Close(function->GetField(struc, *fieldDesc, functionHandle));
+};
+
+v8::Handle<v8::Integer> Function::StructureQuery(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  v8::HandleScope scope;
+  v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
+
+  if (!fieldDescriptions->Has(property)) {
+    v8::Handle<v8::Integer> result;
+    return result;
+  }
+
+  v8::Handle<v8::Integer> result(v8::Integer::New(v8::ReadOnly));
+  return scope.Close(result);
+};
+
+v8::Handle<v8::Array> Function::StructureEnumerate(const v8::AccessorInfo &info) {
+  v8::HandleScope scope;
+  v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
+  return scope.Close(fieldDescriptions->GetOwnPropertyNames());
+};

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -916,6 +916,10 @@ v8::Handle<v8::Value> Function::TableToInternal(const CHND container, const SAP_
   // Create array holding table lines
   v8::Local<v8::Array> obj = v8::Array::New();
 
+  if (rowCount == 0) {
+    return scope.Close(obj);
+  }
+
   RfcMoveToFirstRow(tableHandle, nullptr);
   v8::Handle<v8::Value> fieldDescs = this->BuildFieldDescriptionMap(RfcGetCurrentRow(tableHandle, nullptr), functionHandle);
   if (IsException(fieldDescs)) {

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -49,7 +49,13 @@ void Function::Init(v8::Handle<v8::Object> target)
 
   Function::structureTemplate = v8::Persistent<v8::ObjectTemplate>::New(v8::ObjectTemplate::New());
   Function::structureTemplate->SetInternalFieldCount(4);
-  Function::structureTemplate->SetNamedPropertyHandler(Function::StructureGetter);
+  Function::structureTemplate->SetNamedPropertyHandler(
+    Function::StructureGetter,
+    nullptr,
+    Function::StructureQuery,
+    nullptr,
+    Function::StructureEnumerate
+  );
 }
 
 v8::Handle<v8::Value> Function::NewInstance(Connection &connection, const v8::Arguments &args)

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -545,7 +545,7 @@ v8::Handle<v8::Value> Function::NumToExternal(const CHND container, const SAP_UC
   }
 
   v8::String::Value valueU16(value->ToString());
-  if (valueU16.length() > len) {
+  if (valueU16.length() < 0 || (static_cast<unsigned int>(valueU16.length()) > len)) {
     return RFC_ERROR("Argument exceeds maximum length: ", v8::String::New((const uint16_t*)(name)));
   }
 
@@ -568,7 +568,7 @@ v8::Handle<v8::Value> Function::CharToExternal(const CHND container, const SAP_U
   }
 
   v8::String::Value valueU16(value->ToString());
-  if (valueU16.length() > len) {
+  if (valueU16.length() < 0 || (static_cast<unsigned int>(valueU16.length()) > len)) {
     return RFC_ERROR("Argument exceeds maximum length: ", v8::String::New((const uint16_t*)(name)));
   }
 
@@ -591,7 +591,7 @@ v8::Handle<v8::Value> Function::ByteToExternal(const CHND container, const SAP_U
   }
 
   v8::String::AsciiValue valueAscii(value->ToString());
-  if (valueAscii.length() > len) {
+  if (valueAscii.length() < 0 || (static_cast<unsigned int>(valueAscii.length()) > len)) {
     return RFC_ERROR("Argument exceeds maximum length: ", v8::String::New((const uint16_t*)(name)));
   }
 

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -236,6 +236,9 @@ void Function::EIO_AfterInvoke(uv_work_t *req)
 
   InvocationBaton *baton = static_cast<InvocationBaton*>(req->data);
   assert(baton != nullptr);
+  assert(baton->functionHandle != nullptr);
+
+  v8::Persistent<v8::External> wrappedFunctionHandle = v8::Persistent<v8::External>::New(v8::External::New(baton->functionHandle));
 
   v8::Local<v8::Value> argv[2];
   argv[0] = v8::Local<v8::Value>::New(v8::Null());
@@ -252,10 +255,8 @@ void Function::EIO_AfterInvoke(uv_work_t *req)
     }
   }
 
-  if (baton->functionHandle) {
-    RfcDestroyFunction(baton->functionHandle, &errorInfo);
-    baton->functionHandle = nullptr;
-  }
+  wrappedFunctionHandle.MakeWeak(nullptr, InvocationBaton::DestroyFunctionHandle);
+  baton->functionHandle = nullptr;
 
   v8::TryCatch try_catch;
 

--- a/src/Function.cc
+++ b/src/Function.cc
@@ -1,4 +1,4 @@
-/* 
+/*
 -----------------------------------------------------------------------------
 Copyright (c) 2011 Joachim Dorner
 
@@ -37,7 +37,7 @@ Function::~Function()
 void Function::Init(v8::Handle<v8::Object> target)
 {
   v8::HandleScope scope;
-  
+
   ctorTemplate = v8::Persistent<v8::FunctionTemplate>::New(v8::FunctionTemplate::New(New));
   ctorTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   ctorTemplate->SetClassName(v8::String::NewSymbol("Function"));
@@ -53,7 +53,7 @@ v8::Handle<v8::Value> Function::NewInstance(Connection &connection, const v8::Ar
   unsigned int parmCount;
   RFC_RC rc = RFC_OK;
   RFC_ERROR_INFO errorInfo;
-  
+
   v8::Local<v8::Object> func = ctorTemplate->GetFunction()->NewInstance();
   Function *self = node::ObjectWrap::Unwrap<Function>(func);
 
@@ -73,7 +73,7 @@ v8::Handle<v8::Value> Function::NewInstance(Connection &connection, const v8::Ar
   if (self->functionDescHandle == nullptr) {
     return RFC_ERROR(errorInfo);
   }
-  
+
   rc = RfcGetParameterCount(self->functionDescHandle, &parmCount, &errorInfo);
   if (rc != RFC_OK) {
     return RFC_ERROR(errorInfo);
@@ -82,7 +82,7 @@ v8::Handle<v8::Value> Function::NewInstance(Connection &connection, const v8::Ar
   // Dynamically add parameters to JS object
   for (unsigned int i = 0; i < parmCount; i++) {
     RFC_PARAMETER_DESC parmDesc;
-    
+
     rc = RfcGetParameterDescByIndex(self->functionDescHandle, i, &parmDesc, &errorInfo);
     if (rc != RFC_OK) {
       return RFC_ERROR(errorInfo);
@@ -113,7 +113,7 @@ v8::Handle<v8::Value> Function::Invoke(const v8::Arguments &args)
   RFC_RC rc = RFC_OK;
   unsigned int parmCount;
   RFC_ERROR_INFO errorInfo;
-  
+
   Function *self = node::ObjectWrap::Unwrap<Function>(args.This());
   assert(self != nullptr);
 
@@ -134,7 +134,7 @@ v8::Handle<v8::Value> Function::Invoke(const v8::Arguments &args)
 
   // Store callback
   baton->cbInvoke = v8::Persistent<v8::Function>::New(v8::Local<v8::Function>::Cast(args[1]));
-  
+
   baton->functionHandle = RfcCreateFunction(self->functionDescHandle, &errorInfo);
   if (baton->functionHandle == nullptr) {
     delete baton;
@@ -151,7 +151,7 @@ v8::Handle<v8::Value> Function::Invoke(const v8::Arguments &args)
 
   for (unsigned int i = 0; i < parmCount; i++) {
     RFC_PARAMETER_DESC parmDesc;
-    
+
     rc = RfcGetParameterDescByIndex(self->functionDescHandle, i, &parmDesc, &errorInfo);
     if (rc != RFC_OK) {
       delete baton;
@@ -210,7 +210,7 @@ void Function::EIO_Invoke(uv_work_t *req)
 {
   RFC_RC rc = RFC_OK;
   int isValid;
-  
+
   InvocationBaton *baton = static_cast<InvocationBaton*>(req->data);
 
   assert(baton != nullptr);
@@ -225,7 +225,7 @@ void Function::EIO_Invoke(uv_work_t *req)
   if (baton->errorInfo.code == RFC_INVALID_HANDLE) {
     rc = RfcIsConnectionHandleValid(baton->connection->GetConnectionHandle(), &isValid, &baton->errorInfo);
   }
-  
+
   baton->connection->UnlockMutex();
 }
 
@@ -233,14 +233,14 @@ void Function::EIO_AfterInvoke(uv_work_t *req)
 {
   v8::HandleScope scope;
   RFC_ERROR_INFO errorInfo;
- 
+
   InvocationBaton *baton = static_cast<InvocationBaton*>(req->data);
   assert(baton != nullptr);
-  
+
   v8::Local<v8::Value> argv[2];
   argv[0] = v8::Local<v8::Value>::New(v8::Null());
   argv[1] = v8::Local<v8::Value>::New(v8::Null());
-  
+
   if (baton->errorInfo.code != RFC_OK) {
     argv[0] = v8::Local<v8::Value>::New(RfcError(baton->errorInfo));
   } else {
@@ -276,7 +276,7 @@ v8::Handle<v8::Value> Function::DoReceive(const CHND container)
   RFC_RC rc = RFC_OK;
   RFC_ERROR_INFO errorInfo;
   unsigned int parmCount;
-  
+
   v8::Local<v8::Object> result = v8::Object::New();
 
   // Get resulting values for exporting/changing/table parameters
@@ -288,7 +288,7 @@ v8::Handle<v8::Value> Function::DoReceive(const CHND container)
   for (unsigned int i = 0; i < parmCount; i++) {
     RFC_PARAMETER_DESC parmDesc;
     v8::Handle<v8::Value> parmValue;
-    
+
     rc = RfcGetParameterDescByIndex(this->functionDescHandle, i, &parmDesc, &errorInfo);
     if (rc != RFC_OK) {
       return RFC_ERROR(errorInfo);
@@ -387,7 +387,7 @@ v8::Handle<v8::Value> Function::SetValue(const CHND container, RFCTYPE type, con
     return scope.Close(result);
   }
 
-  return scope.Close(v8::Null());  
+  return scope.Close(v8::Null());
 }
 
 v8::Handle<v8::Value> Function::StructureToExternal(const CHND container, const SAP_UC *name, v8::Handle<v8::Value> value)
@@ -473,7 +473,7 @@ v8::Handle<v8::Value> Function::TableToExternal(const CHND container, const SAP_
 
   for (uint32_t i = 0; i < rowCount; i++){
     strucHandle = RfcAppendNewRow(tableHandle, nullptr);
-    
+
     v8::Handle<v8::Value> line = this->StructureToExternal(container, strucHandle, source->CloneElementAt(i));
     // Bail out on exception
     if (IsException(line)) {
@@ -536,7 +536,7 @@ v8::Handle<v8::Value> Function::NumToExternal(const CHND container, const SAP_UC
   if (valueU16.length() > len) {
     return RFC_ERROR("Argument exceeds maximum length: ", v8::String::New((const uint16_t*)(name)));
   }
-  
+
   rc = RfcSetNum(container, name, (const RFC_NUM*)*valueU16, valueU16.length(), &errorInfo);
   if (rc != RFC_OK) {
     return RFC_ERROR(errorInfo);
@@ -564,7 +564,7 @@ v8::Handle<v8::Value> Function::CharToExternal(const CHND container, const SAP_U
   if (rc != RFC_OK) {
     return RFC_ERROR(errorInfo);
   }
-  
+
   return scope.Close(v8::Null());
 }
 
@@ -582,12 +582,12 @@ v8::Handle<v8::Value> Function::ByteToExternal(const CHND container, const SAP_U
   if (valueAscii.length() > len) {
     return RFC_ERROR("Argument exceeds maximum length: ", v8::String::New((const uint16_t*)(name)));
   }
-  
+
   rc = RfcSetBytes(container, name, reinterpret_cast<SAP_RAW*>(*valueAscii), len, &errorInfo);
   if (rc != RFC_OK) {
     return RFC_ERROR(errorInfo);
   }
-  
+
   return scope.Close(v8::Null());
 }
 
@@ -690,7 +690,7 @@ v8::Handle<v8::Value> Function::DateToExternal(const CHND container, const SAP_U
   if (str->Length() != 8) {
     return RFC_ERROR("Invalid date format: ", v8::String::New((const uint16_t*)(name)));
   }
-  
+
   v8::String::Value rfcValue(str);
   assert(*rfcValue);
   RFC_RC rc = RfcSetDate(container, name, (const RFC_CHAR*)*rfcValue, &errorInfo);
@@ -736,12 +736,12 @@ v8::Handle<v8::Value> Function::BCDToExternal(const CHND container, const SAP_UC
   }
 
   v8::String::Value valueU16(value->ToString());
-    
+
   rc = RfcSetString(container, name, (const SAP_UC*)*valueU16, valueU16.length(), &errorInfo);
   if (rc != RFC_OK) {
     return RFC_ERROR(errorInfo);
   }
-  
+
   return scope.Close(v8::Null());
 }
 
@@ -890,7 +890,7 @@ v8::Handle<v8::Value> Function::TableToInternal(const CHND container, const SAP_
 
   // Create array holding table lines
   v8::Local<v8::Array> obj = v8::Array::New();
-  
+
   for (unsigned int i = 0; i < rowCount; i++){
     RfcMoveTo(tableHandle, i, nullptr);
     strucHandle = RfcGetCurrentRow(tableHandle, nullptr);
@@ -925,17 +925,17 @@ v8::Handle<v8::Value> Function::StringToInternal(const CHND container, const SAP
   SAP_UC *buffer = static_cast<SAP_UC*>(malloc((strLen + 1) * sizeof(SAP_UC)));
   assert(buffer);
   memset(buffer, 0, (strLen + 1) * sizeof(SAP_UC));
-  
+
   rc = RfcGetString(container, name, buffer, strLen + 1, &retStrLen, &errorInfo);
   if (rc != RFC_OK) {
     free(buffer);
     return RFC_ERROR(errorInfo);
   }
-  
+
   v8::Local<v8::String> value = v8::String::New((const uint16_t*)(buffer));
 
   free(buffer);
-      
+
   return scope.Close(value);
 }
 
@@ -958,17 +958,17 @@ v8::Handle<v8::Value> Function::XStringToInternal(const CHND container, const SA
   SAP_RAW *buffer = static_cast<SAP_RAW*>(malloc(strLen * sizeof(SAP_RAW)));
   assert(buffer);
   memset(buffer, 0, strLen * sizeof(SAP_RAW));
-  
+
   rc = RfcGetXString(container, name, buffer, strLen, &retStrLen, &errorInfo);
   if (rc != RFC_OK) {
     free(buffer);
     return RFC_ERROR(errorInfo);
   }
-  
+
   v8::Local<v8::String> value = v8::String::New(reinterpret_cast<char*>(buffer), strLen);
 
   free(buffer);
-      
+
   return scope.Close(value);
 }
 
@@ -980,17 +980,17 @@ v8::Handle<v8::Value> Function::NumToInternal(const CHND container, const SAP_UC
   RFC_NUM *buffer = static_cast<RFC_NUM*>(malloc((len + 1) * sizeof(RFC_NUM)));
   assert(buffer);
   memset(buffer, 0, (len + 1) * sizeof(RFC_NUM));
-  
+
   RFC_RC rc = RfcGetNum(container, name, buffer, len, &errorInfo);
   if (rc != RFC_OK) {
     free(buffer);
     return RFC_ERROR(errorInfo);
   }
-  
+
   v8::Local<v8::String> value = v8::String::New((const uint16_t*)(buffer));
 
   free(buffer);
-      
+
   return scope.Close(value);
 }
 
@@ -1002,17 +1002,17 @@ v8::Handle<v8::Value> Function::CharToInternal(const CHND container, const SAP_U
   RFC_CHAR *buffer = static_cast<RFC_CHAR*>(malloc((len + 1) * sizeof(RFC_CHAR)));
   assert(buffer);
   memset(buffer, 0, (len + 1) * sizeof(RFC_CHAR));
-  
+
   RFC_RC rc = RfcGetChars(container, name, buffer, len, &errorInfo);
   if (rc != RFC_OK) {
     free(buffer);
     return RFC_ERROR(errorInfo);
   }
-  
+
   v8::Local<v8::String> value = v8::String::New((const uint16_t*)(buffer));
 
   free(buffer);
-      
+
   return scope.Close(value);
 }
 
@@ -1024,17 +1024,17 @@ v8::Handle<v8::Value> Function::ByteToInternal(const CHND container, const SAP_U
   RFC_BYTE *buffer = static_cast<RFC_BYTE*>(malloc(len * sizeof(RFC_BYTE)));
   assert(buffer);
   memset(buffer, 0, len * sizeof(RFC_BYTE));
-  
+
   RFC_RC rc = RfcGetBytes(container, name, buffer, len, &errorInfo);
   if (rc != RFC_OK) {
     free(buffer);
     return RFC_ERROR(errorInfo);
   }
-  
+
   v8::Local<v8::String> value = v8::String::New(reinterpret_cast<const char*>(buffer));
 
   free(buffer);
-      
+
   return scope.Close(value);
 }
 
@@ -1124,7 +1124,7 @@ v8::Handle<v8::Value> Function::TimeToInternal(const CHND container, const SAP_U
 
   assert(sizeof(RFC_CHAR) > 0); // Shouldn't occur except in case of a compiler glitch
   v8::Local<v8::String> value = v8::String::New((const uint16_t*)(time), sizeof(RFC_TIME) / sizeof(RFC_CHAR));
-      
+
   return scope.Close(value);
 }
 
@@ -1141,7 +1141,7 @@ v8::Handle<v8::Value> Function::BCDToInternal(const CHND container, const SAP_UC
     buffer = static_cast<SAP_UC*>(malloc((strLen + 1) * sizeof(SAP_UC)));
     assert(buffer);
     memset(buffer, 0, (strLen + 1) * sizeof(SAP_UC));
-  
+
     rc = RfcGetString(container, name, buffer, strLen + 1, &retStrLen, &errorInfo);
 
     if (rc == RFC_BUFFER_TOO_SMALL) {
@@ -1152,10 +1152,10 @@ v8::Handle<v8::Value> Function::BCDToInternal(const CHND container, const SAP_UC
       return RFC_ERROR(errorInfo);
     }
   } while (rc == RFC_BUFFER_TOO_SMALL);
-  
+
   v8::Local<v8::String> value = v8::String::New((const uint16_t*)(buffer), retStrLen);
 
   free(buffer);
-      
+
   return scope.Close(value->ToNumber());
 }

--- a/src/Function.h
+++ b/src/Function.h
@@ -102,7 +102,6 @@ class Function : public node::ObjectWrap
     };
 
     static void DestroyFunctionHandle(v8::Persistent<v8::Value> value, void *parameters) {
-      printf("Destructed\n");
       v8::Handle<v8::External> wrappedFunctionHandle = v8::Handle<v8::External>::Cast(value);
       RFC_FUNCTION_HANDLE functionHandle = static_cast<RFC_FUNCTION_HANDLE>(wrappedFunctionHandle->Value());
       RFC_ERROR_INFO errorInfo;

--- a/src/Function.h
+++ b/src/Function.h
@@ -93,7 +93,9 @@ class Function : public node::ObjectWrap
   v8::Handle<v8::Value> BCDToInternal(const CHND container, const SAP_UC *name);
 
   static v8::Handle<v8::Value> StructureGetter(v8::Local<v8::String> property, const v8::AccessorInfo &info);
+  static v8::Handle<v8::Value> StructureSetter(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::AccessorInfo &info);
   static v8::Handle<v8::Integer> StructureQuery(v8::Local<v8::String> property, const v8::AccessorInfo &info);
+  static v8::Handle<v8::Boolean> StructureDeleter(v8::Local<v8::String> property, const v8::AccessorInfo &info);
   static v8::Handle<v8::Array> StructureEnumerate(const v8::AccessorInfo &info);
 
   class InvocationBaton

--- a/src/Function.h
+++ b/src/Function.h
@@ -50,7 +50,7 @@ class Function : public node::ObjectWrap
   static void EIO_Invoke(uv_work_t *req);
   static void EIO_AfterInvoke(uv_work_t *req);
 
-  v8::Handle<v8::Value> DoReceive(const CHND container);
+  v8::Handle<v8::Value> DoReceive(const CHND container, v8::Persistent<v8::External> functionHandle);
 
   v8::Handle<v8::Value> SetParameter(const CHND container, RFC_PARAMETER_DESC &desc, v8::Handle<v8::Value> value);
   v8::Handle<v8::Value> SetField(const CHND container, RFC_FIELD_DESC &desc, v8::Handle<v8::Value> value);
@@ -71,12 +71,12 @@ class Function : public node::ObjectWrap
   v8::Handle<v8::Value> DateToExternal(const CHND container, const SAP_UC *name, v8::Handle<v8::Value> value);
   v8::Handle<v8::Value> BCDToExternal(const CHND container, const SAP_UC *name, v8::Handle<v8::Value> value);
 
-  v8::Handle<v8::Value> GetParameter(const CHND container, const RFC_PARAMETER_DESC &desc);
-  v8::Handle<v8::Value> GetField(const CHND container, const RFC_FIELD_DESC &desc);
-  v8::Handle<v8::Value> GetValue(const CHND container, RFCTYPE type, const SAP_UC *name, unsigned len);
-  v8::Handle<v8::Value> StructureToInternal(const CHND container, const SAP_UC *name);
-  v8::Handle<v8::Value> StructureToInternal(const CHND container, const RFC_STRUCTURE_HANDLE struc);
-  v8::Handle<v8::Value> TableToInternal(const CHND container, const SAP_UC *name);
+  v8::Handle<v8::Value> GetParameter(const CHND container, const RFC_PARAMETER_DESC &desc, v8::Persistent<v8::External> functionHandle);
+  v8::Handle<v8::Value> GetField(const CHND container, const RFC_FIELD_DESC &desc, v8::Persistent<v8::External> functionHandle);
+  v8::Handle<v8::Value> GetValue(const CHND container, RFCTYPE type, const SAP_UC *name, unsigned len, v8::Persistent<v8::External> functionHandle);
+  v8::Handle<v8::Value> StructureToInternal(const CHND container, const SAP_UC *name, v8::Persistent<v8::External> functionHandle);
+  v8::Handle<v8::Value> StructureToInternal(const CHND container, const RFC_STRUCTURE_HANDLE struc, v8::Persistent<v8::External> functionHandle);
+  v8::Handle<v8::Value> TableToInternal(const CHND container, const SAP_UC *name, v8::Persistent<v8::External> functionHandle);
   v8::Handle<v8::Value> StringToInternal(const CHND container, const SAP_UC *name);
   v8::Handle<v8::Value> XStringToInternal(const CHND container, const SAP_UC *name);
   v8::Handle<v8::Value> NumToInternal(const CHND container, const SAP_UC *name, unsigned len);

--- a/src/Function.h
+++ b/src/Function.h
@@ -139,6 +139,25 @@ class Function : public node::ObjectWrap
     return scope.Close(function->GetField(struc, *fieldDesc, functionHandle));
   };
 
+  static v8::Handle<v8::Integer> StructureQuery(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+    v8::HandleScope scope;
+    v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
+
+    if (!fieldDescriptions->Has(property)) {
+      v8::Handle<v8::Integer> result;
+      return result;
+    }
+
+    v8::Handle<v8::Integer> result(v8::Integer::New(v8::ReadOnly));
+    return scope.Close(result);
+  };
+
+  static v8::Handle<v8::Array> StructureEnumerate(const v8::AccessorInfo &info) {
+    v8::HandleScope scope;
+    v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
+    return scope.Close(fieldDescriptions->GetOwnPropertyNames());
+  };
+
   static void DestroyFieldDesc(v8::Persistent<v8::Value> value, void *parameters) {
     v8::Handle<v8::External> wrappedFieldDesc = v8::Handle<v8::External>::Cast(value);
     RFC_FIELD_DESC *fieldDesc = static_cast<RFC_FIELD_DESC *>(wrappedFieldDesc->Value());

--- a/src/Function.h
+++ b/src/Function.h
@@ -92,6 +92,10 @@ class Function : public node::ObjectWrap
   v8::Handle<v8::Value> TimeToInternal(const CHND container, const SAP_UC *name);
   v8::Handle<v8::Value> BCDToInternal(const CHND container, const SAP_UC *name);
 
+  static v8::Handle<v8::Value> StructureGetter(v8::Local<v8::String> property, const v8::AccessorInfo &info);
+  static v8::Handle<v8::Integer> StructureQuery(v8::Local<v8::String> property, const v8::AccessorInfo &info);
+  static v8::Handle<v8::Array> StructureEnumerate(const v8::AccessorInfo &info);
+
   class InvocationBaton
   {
     public:
@@ -120,43 +124,6 @@ class Function : public node::ObjectWrap
 
   static v8::Persistent<v8::FunctionTemplate> ctorTemplate;
   static v8::Persistent<v8::ObjectTemplate> structureTemplate;
-
-  static v8::Handle<v8::Value> StructureGetter(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
-    v8::HandleScope scope;
-    Function *function = static_cast<Function *>(info.This()->GetPointerFromInternalField(0));
-    RFC_STRUCTURE_HANDLE struc = static_cast<RFC_STRUCTURE_HANDLE>(info.This()->GetPointerFromInternalField(1));
-    v8::Handle<v8::External> functionHandle = v8::Handle<v8::External>::Cast(info.This()->GetInternalField(2));
-    v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
-
-    if (!fieldDescriptions->Has(property)) {
-      v8::Handle<v8::Value> result;
-      return result;
-    }
-
-    v8::Handle<v8::External> wrappedFieldDesc = v8::Handle<v8::External>::Cast(fieldDescriptions->Get(property));
-    RFC_FIELD_DESC *fieldDesc = static_cast<RFC_FIELD_DESC *>(wrappedFieldDesc->Value());
-
-    return scope.Close(function->GetField(struc, *fieldDesc, functionHandle));
-  };
-
-  static v8::Handle<v8::Integer> StructureQuery(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
-
-    if (!fieldDescriptions->Has(property)) {
-      v8::Handle<v8::Integer> result;
-      return result;
-    }
-
-    v8::Handle<v8::Integer> result(v8::Integer::New(v8::ReadOnly));
-    return scope.Close(result);
-  };
-
-  static v8::Handle<v8::Array> StructureEnumerate(const v8::AccessorInfo &info) {
-    v8::HandleScope scope;
-    v8::Local<v8::Object> fieldDescriptions = v8::Local<v8::Object>::Cast(info.This()->GetInternalField(3));
-    return scope.Close(fieldDescriptions->GetOwnPropertyNames());
-  };
 
   static void DestroyFieldDesc(v8::Persistent<v8::Value> value, void *parameters) {
     v8::Handle<v8::External> wrappedFieldDesc = v8::Handle<v8::External>::Cast(value);

--- a/src/Function.h
+++ b/src/Function.h
@@ -95,17 +95,18 @@ class Function : public node::ObjectWrap
     public:
     InvocationBaton() : function(nullptr), functionHandle(nullptr) { };
     ~InvocationBaton() {
-      RFC_ERROR_INFO errorInfo;
-
-      if (this->functionHandle) {
-        RfcDestroyFunction(this->functionHandle, &errorInfo);
-        this->functionHandle = nullptr;
-      }
-
       if (!this->cbInvoke.IsEmpty()) {
         this->cbInvoke.Dispose();
         this->cbInvoke.Clear();
       }
+    };
+
+    static void DestroyFunctionHandle(v8::Persistent<v8::Value> value, void *parameters) {
+      printf("Destructed\n");
+      v8::Handle<v8::External> wrappedFunctionHandle = v8::Handle<v8::External>::Cast(value);
+      RFC_FUNCTION_HANDLE functionHandle = static_cast<RFC_FUNCTION_HANDLE>(wrappedFunctionHandle->Value());
+      RFC_ERROR_INFO errorInfo;
+      RfcDestroyFunction(functionHandle, &errorInfo);
     };
 
     Function *function;

--- a/src/Function.h
+++ b/src/Function.h
@@ -1,4 +1,4 @@
-/* 
+/*
 -----------------------------------------------------------------------------
 Copyright (c) 2011 Joachim Dorner
 
@@ -43,7 +43,7 @@ class Function : public node::ObjectWrap
   protected:
   Function();
   ~Function();
-  
+
   static v8::Handle<v8::Value> New(const v8::Arguments &args);
   static v8::Handle<v8::Value> Invoke(const v8::Arguments &args);
 
@@ -96,7 +96,7 @@ class Function : public node::ObjectWrap
     InvocationBaton() : function(nullptr), functionHandle(nullptr) { };
     ~InvocationBaton() {
       RFC_ERROR_INFO errorInfo;
-    
+
       if (this->functionHandle) {
         RfcDestroyFunction(this->functionHandle, &errorInfo);
         this->functionHandle = nullptr;
@@ -116,7 +116,7 @@ class Function : public node::ObjectWrap
   };
 
   static v8::Persistent<v8::FunctionTemplate> ctorTemplate;
-  
+
   //RFC_CONNECTION_HANDLE connectionHandle;
   Connection *connection;
   RFC_FUNCTION_DESC_HANDLE functionDescHandle;


### PR DESCRIPTION
Receiving large tables and structures required lots of memory (see #9). The reason was that the addon stored structures in plain v8::Object, created a v8::String for each property and other objects for values. Moreover, all fields of the SAP structures were converted to v8::Object properties, even they were never read.

I've used `v8::ObjectTemplate` to represent a SAP structure and `v8::ObjectTemplate::SetNamedPropertyHandler` to convert SAP structure properties to JS ones, just-in-time.

Finally, IsException() method was really slow, so we practically couldn't receive large tables through RFC. I've used `v8::Value::IsNativeError()` to speed up the check.