### PR TITLE
Start loop with with 0.

### DIFF
--- a/src/Function.cc
+++ b/src/Function.cc
@@ -532,7 +532,7 @@ v8::Local<v8::Value> Function::TableToExternal(const CHND container, const SAP_U
   v8::Local<v8::Array> source = v8::Local<v8::Array>::Cast(value);
   rowCount = source->Length();
 
-  for (uint32_t i = 1; i <= rowCount; i++){
+  for (uint32_t i = 0; i < rowCount; i++){
     strucHandle = RfcAppendNewRow(tableHandle, nullptr);
 
     v8::Local<v8::Value> line = this->StructureToExternal(container, strucHandle, source->Get(i));


### PR DESCRIPTION
@seal-mis and I have debugged a problem sending a table to SAP. We found an off-by-one error in `TableToExternal` and fixed the offset to zero.

We wanted to send one job event back to SAP with `SXMI_XOM_JOBS_CALLBACK` but the trace files showed an empty row. After the fix the event is sent with all data needed in the table row to SAP.
