### PR TITLE
Do not try to compile under Darwin.

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -1,11 +1,10 @@
+var os = require('os');
 var child_process = require('child_process');
 var red = '\u001b[31m',
   green = '\u001b[32m',
   reset = '\u001b[0m';
 
-var nodeGyp = function () {
-  var os = require('os');
-
+var nodeGyp = function() {
   switch (os.platform()) {
     case 'win32':
       return 'node-gyp.cmd';
@@ -16,7 +15,11 @@ var nodeGyp = function () {
   }
 };
 
-var rebuild = function () {
+var rebuild = function() {
+  if (os.platform() === 'darwin') {
+    return console.log('NOT SUPPORTED UNDER DARWIN.');
+  };
+
   try {
     var majMinVersion = process.versions.node.match(/^[0-9]+.[0-9]+/)[0] || '';
     var bindings = require('bindings')({ bindings: 'sapnwrfc', version: majMinVersion });


### PR DESCRIPTION
@seal-mis has added another improvement to make development on a Mac much easier. We code on MacBookPro's and clone our source and run `npm install` on OSX. Then we run Docker containers for unit and integration tests which is Linux based. So with this addition we are able to install your module with the precompiled binaries for Linux and then run it in a Docker container without the need of recompiling it inside the Container.
