### PR TITLE
Add function SetIniPath()

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ var conParams = {
 };
 ```
 
+## Set path to sapnwrfc.ini
+
+Befor you open a connection you can set the directory path to look for the `sapnwrfc.ini` file.
+
+Example:
+
+```js
+var con = new sapnwrfc.Connection;
+var iniPath = '/path/to/dir/with/inifile/in/it'
+
+con.SetIniPath(iniPath);
+```
+
 ## Opening the connection
 
 Before you can invoke a remote function, you will have to open a connection to the SAP system.

--- a/src/Connection.cc
+++ b/src/Connection.cc
@@ -77,6 +77,7 @@ NAN_MODULE_INIT(Connection::Init)
   Nan::SetPrototypeMethod(ctorTemplate, "Ping", Connection::Ping);
   Nan::SetPrototypeMethod(ctorTemplate, "IsOpen", Connection::IsOpen);
   Nan::SetPrototypeMethod(ctorTemplate, "Lookup", Connection::Lookup);
+  Nan::SetPrototypeMethod(ctorTemplate, "SetIniPath", Connection::SetIniPath);
 
   Nan::Set(target, Nan::New("Connection").ToLocalChecked(), ctorTemplate->GetFunction());
 }
@@ -286,4 +287,36 @@ NAN_METHOD(Connection::Lookup)
 
   v8::Local<v8::Value> f = Function::NewInstance(*self, info);
   info.GetReturnValue().Set(f);
+}
+
+/**
+ *
+ * @return true if successful, else: RfcException
+ */
+NAN_METHOD(Connection::SetIniPath)
+{
+  RFC_RC rc = RFC_OK;
+  RFC_ERROR_INFO errorInfo;
+  int isValid;
+
+  Connection *self = node::ObjectWrap::Unwrap<Connection>(info.This());
+
+  if (info.Length() != 1) {
+    THROW_V8_EXCEPTION("Function expects 1 argument");
+    return;
+  }
+  if (!info[0]->IsString()) {
+    THROW_V8_EXCEPTION("Argument 1 must be a path name");
+    return;
+  }
+
+  v8::Local<v8::Value> iniPath = info[0]->ToString();
+
+  rc = RfcSetIniPath(convertToSAPUC(iniPath), &errorInfo);
+  if (rc) {
+    THROW_V8_EXCEPTION(RfcError(errorInfo));
+    return;
+  }
+
+  info.GetReturnValue().Set(Nan::True());
 }

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -52,6 +52,7 @@ class Connection : public node::ObjectWrap
     static NAN_METHOD(Ping);
     static NAN_METHOD(Lookup);
     static NAN_METHOD(IsOpen);
+    static NAN_METHOD(SetIniPath);
 
     static void EIO_Open(uv_work_t *req);
     static void EIO_AfterOpen(uv_work_t *req);

--- a/tests/testSetIniPath.js
+++ b/tests/testSetIniPath.js
@@ -1,0 +1,28 @@
+/* global describe, before, it */
+var mocha = require('mocha');
+var should = require('should');
+var sapnwrfc = require('../sapnwrfc');
+
+describe('SetIniPath', function () {
+  var con = undefined;
+
+  before(function() {
+    con = new sapnwrfc.Connection;
+  });
+
+  it('should work with current dir', function () {
+    var rc = con.SetIniPath('.');
+    rc.should.be.true();
+  });
+
+  it('should work with parent dir', function () {
+    var rc = con.SetIniPath('..');
+    rc.should.be.true();
+  });
+
+  it('should not throw an exception with non existing dir', function () {
+    (function () {
+      con.SetIniPath('/this/directory/does/not/exist');
+    }).should.not.throw();
+  });
+});


### PR DESCRIPTION
In our project we would like to put the `sapnwrfc.ini` into a config directory. I have seen that there is a `RfcSetIniPath()` function in the SDK.

I have added a binding function `SetIniPath()` and some tests.
