### PR TITLE
Crash early without credentials

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - git checkout %APPVEYOR_REPO_BRANCH%
   - ps: Install-Product node $env:nodejs_version $env:platform
   - ps: choco install -y curl
+  - if not defined SAPNWRFC_CRED ( exit 1 )
   - curl -L -u %SAPNWRFC_CRED% -o SAPCAR_0-80000938.EXE "https://smpdla.sap.com/00000674/279/SAPCAR_0-80000938.EXE?object_id=012002523100006086842015D&filepath=00000674%%%%5c279%%%%5cSAPCAR_0-80000938%%%%2eEXE&uid=S0015138022&LOC=FRA&iesfx=.exe"
   - curl -L -u %SAPNWRFC_CRED% -o NWRFC_36-20004568.SAR "https://smpdl.sap-ag.de/~swdc/012002523100013832132015D/NWRFC_36-20004568.SAR?_ACTION=DL_DIRECT"
   - .\SAPCAR_0-80000938.EXE -xvf NWRFC_36-20004568.SAR


### PR DESCRIPTION
To prevent hanging downloads with curl abort the install script.

This is no solution to build and test PR's with AppVeyor, it just crashes faster.

